### PR TITLE
fix: add fallback to winfsp install command (powershell) (cmd) incase powershell is not accessible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,11 +296,17 @@ export class NetworkDrive {
 
 		try {
 			await new Promise<void>((resolve, reject) => {
-				exec(`"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" -Command "Start-Process msiexec -ArgumentList '/i ${tempPath} /qn' -Verb runAs -Wait"`, err => {
+				exec(`"%SYSTEMROOT%/System32/WindowsPowerShell/v1.0/powershell.exe" -Command "Start-Process msiexec -ArgumentList '/i ${tempPath} /qn' -Verb runAs -Wait"`, err => {
 					if (err) {
-						reject(err)
-
-						return
+						this.logger.log("warn", "powershell not at '%SYSTEMROOT%/System32/WindowsPowerShell/v1.0/powershell.exe', falling back to CommandPrompt (cmd)")
+						// Fallback, using cmd prompt
+						exec(`cmd /B runas /user:Administrator "msiexec /i ${tempPath} /qn"`, err => {
+							if (err) {
+								this.logger.log("error", "Fallback failed, WinFSP failed to check")
+								reject(err)
+								return
+							}
+						})
 					}
 
 					resolve()

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,7 @@ export class NetworkDrive {
 
 		try {
 			await new Promise<void>((resolve, reject) => {
-				exec(`powershell -Command "Start-Process msiexec -ArgumentList '/i ${tempPath} /qn' -Verb runAs -Wait"`, err => {
+				exec(`"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" -Command "Start-Process msiexec -ArgumentList '/i ${tempPath} /qn' -Verb runAs -Wait"`, err => {
 					if (err) {
 						reject(err)
 


### PR DESCRIPTION
Its in the title, check over commits. I had an issue with it, and debugged it myself. Found the error and wanted other users not to fall in the trap. 